### PR TITLE
Use docker for Linux build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,4 +34,4 @@ install:
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing pyepics"
 
 on_success:
-  - anaconda -t %CONDA_TOKEN% upload %MINICONDA%\\conda-bld\\win-%PYTHON_ARCH%\\*.tar.bz2
+  - if defined CONDA_TOKEN (anaconda -t %CONDA_TOKEN% upload %MINICONDA%\\conda-bld\\win-%PYTHON_ARCH%\\*.tar.bz2)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q --all
+  - conda config --add channels defaults
   - conda install conda-build numpy anaconda-client
   # build
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing brotli"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ language: cpp
 matrix:
   include:
     - os: linux
+      dist: trusty
       env: CONDA_PY=2.7
     - os: linux
+      dist: trusty
       env: CONDA_PY=3.5
     - os: osx
       env: CONDA_PY=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
 install:
   # Expand CONDA_CMD alias
   - shopt -s expand_aliases
-  # empty if glob matches no files
-  - shopt -s nullglob
   # Set the anaconda environment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "$CONDA_PY" == "2.7" ]]; then
@@ -37,30 +35,23 @@ install:
       mkdir -m 777 -p ${HOME}/miniconda/conda-bld;
       ./start_docker.sh ${HOME}/miniconda/conda-bld;
       alias CONDA_CMD="./conda_in_docker.sh";
-      export DOCKER_PREFIX="docker exec psi_conda";
     fi
   - CONDA_CMD config --set always_yes yes --set changeps1 no
+  - CONDA_CMD config --set anaconda_upload yes
   - CONDA_CMD update -q --all
   - CONDA_CMD config --add channels defaults
   - CONDA_CMD install conda-build numpy anaconda-client
   # build
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing brotli
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing readline'
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing epics-base
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing pyepics
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing h5py
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing lzf
-  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing bottle
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing zeromq'
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing cx_oracle'
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing brotli
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing readline'
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing epics-base
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing pyepics
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing h5py
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing lzf
+  - CONDA_CMD build -c $CONDA_CHANNEL ---token $CONDA_TOKEN -skip-existing bottle
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing zeromq'
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing cx_oracle'
 
 script:
   - echo "No test scripts to be run!"
 
-deploy:
-  provider: script
-  script:
-    - ls $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/
-    - for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do
-        ${DOCKER_PREFIX} anaconda -t $CONDA_TOKEN upload ${fname};
-      done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-service:
+services:
     - docker
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
       mkdir -m 777 -p ${HOME}/miniconda/conda-bld;
       ./start_docker.sh ${HOME}/miniconda/conda-bld;
       alias CONDA_CMD="./conda_in_docker.sh";
-      export DOCKER_PREFIX="docker exec psi_conda"
+      export DOCKER_PREFIX="docker exec psi_conda";
     fi
   - CONDA_CMD config --set always_yes yes --set changeps1 no
   - CONDA_CMD update -q --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: false
+sudo: required
+
+service:
+    - docker
 
 language: cpp
 
@@ -20,35 +23,35 @@ install:
         curl https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh;
       else
         curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh;
-      fi
+      fi;
+      bash miniconda.sh -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+      alias CONDA_CMD=conda;
+      alias ANACONDA_CMD=anaconda;
     else
-      if [[ "$CONDA_PY" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      fi
+      mkdir -m 777 -p ${HOME}/miniconda/conda-bld;
+      ./start_docker.sh ${HOME}/miniconda/conda-bld;
+      alias CONDA_CMD="./conda_in_docker.sh";
+      alias ANACONDA_CMD="docker exec psi_conda anaconda";
     fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q --all
-  - conda config --add channels defaults
-  - conda install conda-build numpy anaconda-client
+  - CONDA_CMD config --set always_yes yes --set changeps1 no
+  - CONDA_CMD update -q --all
+  - CONDA_CMD config --add channels defaults
+  - CONDA_CMD install conda-build numpy anaconda-client
   # build
-  - conda build -c $CONDA_CHANNEL --skip-existing brotli
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || conda build -c $CONDA_CHANNEL --skip-existing readline'
-  - conda build -c $CONDA_CHANNEL --skip-existing epics-base
-  - conda build -c $CONDA_CHANNEL --skip-existing pyepics
-  - conda build -c $CONDA_CHANNEL --skip-existing h5py
-  - conda build -c $CONDA_CHANNEL --skip-existing lzf
-  - conda build -c $CONDA_CHANNEL --skip-existing bottle
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || conda build -c $CONDA_CHANNEL --skip-existing zeromq'
-  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || conda build -c $CONDA_CHANNEL --skip-existing cx_oracle'
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing brotli
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing readline'
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing epics-base
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing pyepics
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing h5py
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing lzf
+  - CONDA_CMD build -c $CONDA_CHANNEL --skip-existing bottle
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing zeromq'
+  - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --skip-existing cx_oracle'
 
 script:
   - echo "No test scripts to be run!"
 
 deploy:
   provider: script
-  script: find $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64 -name "*.tar.bz2" -exec anaconda -t $CONDA_TOKEN upload {} \;
+  script: find $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64 -name "*.tar.bz2" -exec ANACONDA_CMD -t $CONDA_TOKEN upload {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
 install:
   # Expand CONDA_CMD and ANACONDA_CMD alias
   - shopt -s expand_aliases
+  # empty if glob matches no files
+  - shopt -s nullglob
   # Set the anaconda environment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "$CONDA_PY" == "2.7" ]]; then
@@ -58,4 +60,4 @@ script:
 
 deploy:
   provider: script
-  script: find $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64 -name "*.tar.bz2" -exec ANACONDA_CMD -t $CONDA_TOKEN upload {} \;
+  script: for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do ANACONDA_CMD -t $CONDA_TOKEN upload ${fname}; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: CONDA_PY=3.5
 
 install:
+  # Expand CONDA_CMD and ANACONDA_CMD alias
+  - shopt -s expand_aliases
   # Set the anaconda environment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "$CONDA_PY" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,8 @@ script:
 
 deploy:
   provider: script
-  script: for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do ${DOCKER_PREFIX} anaconda -t $CONDA_TOKEN upload ${fname}; done
+  script:
+    - ls $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/
+    - for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do
+        ${DOCKER_PREFIX} anaconda -t $CONDA_TOKEN upload ${fname};
+      done

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing pyepics
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing h5py
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing lzf
-  - CONDA_CMD build -c $CONDA_CHANNEL ---token $CONDA_TOKEN -skip-existing bottle
+  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing bottle
   - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing zeromq'
   - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing cx_oracle'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       env: CONDA_PY=3.5
 
 install:
-  # Expand CONDA_CMD and ANACONDA_CMD alias
+  # Expand CONDA_CMD alias
   - shopt -s expand_aliases
   # empty if glob matches no files
   - shopt -s nullglob
@@ -33,12 +33,11 @@ install:
       bash miniconda.sh -b -p $HOME/miniconda;
       export PATH="$HOME/miniconda/bin:$PATH";
       alias CONDA_CMD=conda;
-      alias ANACONDA_CMD=anaconda;
     else
       mkdir -m 777 -p ${HOME}/miniconda/conda-bld;
       ./start_docker.sh ${HOME}/miniconda/conda-bld;
       alias CONDA_CMD="./conda_in_docker.sh";
-      alias ANACONDA_CMD="docker exec psi_conda anaconda";
+      export DOCKER_PREFIX="docker exec psi_conda"
     fi
   - CONDA_CMD config --set always_yes yes --set changeps1 no
   - CONDA_CMD update -q --all
@@ -60,4 +59,4 @@ script:
 
 deploy:
   provider: script
-  script: for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do ANACONDA_CMD -t $CONDA_TOKEN upload ${fname}; done
+  script: for fname in $HOME/miniconda/conda-bld/${TRAVIS_OS_NAME}-64/*.tar.bz2; do ${DOCKER_PREFIX} anaconda -t $CONDA_TOKEN upload ${fname}; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,10 @@ install:
       alias CONDA_CMD="./conda_in_docker.sh";
     fi
   - CONDA_CMD config --set always_yes yes --set changeps1 no
-  - CONDA_CMD config --set anaconda_upload yes
+  - '[[ -z "$CONDA_TOKEN" ]] || CONDA_CMD config --set anaconda_upload yes'
+  - if [[ -z "$CONDA_TOKEN" ]]; then
+      export CONDA_TOKEN=token_placeholder;
+    fi
   - CONDA_CMD update -q --all
   - CONDA_CMD config --add channels defaults
   - CONDA_CMD install conda-build numpy anaconda-client

--- a/conda_in_docker.sh
+++ b/conda_in_docker.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker exec psi_conda bash -c "cd /tmp/recipes;if [ ! -z "${CONDA_PY}" ]; then export CONDA_PY=${CONDA_PY}; fi;conda $*"

--- a/epics-base/config_readline.diff
+++ b/epics-base/config_readline.diff
@@ -1,0 +1,24 @@
+--- configure/os/CONFIG_SITE.Common.linux-x86
++++ configure/os/CONFIG_SITE.Common.linux-x86
+@@ -22,7 +22,7 @@
+ # comment them all out to build without readline support.
+ 
+ # No other libraries needed (recent Fedora, Ubuntu etc.):
+-COMMANDLINE_LIBRARY = READLINE
++#COMMANDLINE_LIBRARY = READLINE
+ 
+ # Needs -lncurses (RHEL 5 etc.):
+ #COMMANDLINE_LIBRARY = READLINE_NCURSES
+
+--- configure/os/CONFIG_SITE.Common.linux-x86_64
++++ configure/os/CONFIG_SITE.Common.linux-x86_64
+@@ -22,7 +22,7 @@
+ # comment them all out to build without readline support.
+ 
+ # No other libraries needed (recent Fedora, Ubuntu etc.):
+-COMMANDLINE_LIBRARY = READLINE
++#COMMANDLINE_LIBRARY = READLINE
+ 
+ # Needs -lncurses (RHEL 5 etc.):
+ #COMMANDLINE_LIBRARY = READLINE_NCURSES
+

--- a/epics-base/meta.yaml
+++ b/epics-base/meta.yaml
@@ -9,6 +9,7 @@ source:
     patches:
         - config_site.diff [not win]
         - config_common.diff [not win]
+        - config_readline.diff [linux]
 
 build:
   number: 1
@@ -18,10 +19,6 @@ requirements:
     - m2w64-make [win]
     - perl [win]
     - patch [win]
-    - readline [linux]
-
-  run:
-    - readline [linux]
 
 about:
     home: http://www.aps.anl.gov/epics

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker run -dt --name "psi_conda" -e 'PATH=/opt/miniconda/bin:/usr/bin/:/bin:/usr/sbin:/sbin' -v `pwd`:/tmp/recipes -v ${1}:/opt/miniconda/conda-bld continuumio/anaconda-build-linux-64:latest bash
+docker exec psi_conda sudo yum install -y gcc gcc-c++

--- a/stop_docker.sh
+++ b/stop_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker stop psi_conda
+docker rm psi_conda


### PR DESCRIPTION
It uses the official continuumio/anaconda-build-Linux-64, but installs the system gcc. Because the gcc5 default uses the cxx11 ABI https://gcc.gnu.org/onlinedocs/libstdc%2B%2B/manual/using_dual_abi.html, and this would require change of all recipes to define  _GLIBCXX_USE_CXX11_ABI=0 macro. This is a tedious procedure.

Another change to epics-base is to build without readline library.