### PR TITLE
Fix build on Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   # Set the anaconda environment
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       if [[ "$CONDA_PY" == "2.7" ]]; then
-        curl https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh;
+        curl https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -o miniconda.sh;
       else
         curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh;
       fi;

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 docker run -dt --name "psi_conda" -e 'PATH=/opt/miniconda/bin:/usr/bin/:/bin:/usr/sbin:/sbin' -v `pwd`:/tmp/recipes -v ${1}:/opt/miniconda/conda-bld continuumio/anaconda-build-linux-64:latest bash
+docker exec psi_conda sudo bash -c "rm /etc/yum.repos.d/*.repo"
+docker exec psi_conda bash -c 'echo "[base]" | sudo tee -a /etc/yum.conf'
+docker exec psi_conda bash -c 'echo "name=Centos-5.11 - Base" | sudo tee -a /etc/yum.conf'
+docker exec psi_conda bash -c 'echo "baseurl=http://vault.centos.org/5.11/os/\$basearch/" | sudo tee -a /etc/yum.conf'
 docker exec psi_conda sudo yum install -y gcc gcc-c++


### PR DESCRIPTION
Recently Anaconda changed miniconda 2 download URL from Miniconda-latest-xxx to Miniconda2-latest-xxx. This gets fixed in the macOS build.

Centos 5 is officially end-of-life and goes to vault, http://vault.centos.org/5.11. The yum repository has to be adjusted to install gcc and gcc-c++.