### PR TITLE
Do not upload h5py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - '[[ "$TRAVIS_OS_NAME" != "linux" ]] || CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing readline'
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing epics-base
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing pyepics
-  - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing h5py
+  #- CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing h5py
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing lzf
   - CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing bottle
   #- CONDA_CMD build -c $CONDA_CHANNEL --token $CONDA_TOKEN --skip-existing bitshuffle

--- a/h5py/meta.yaml
+++ b/h5py/meta.yaml
@@ -7,6 +7,9 @@ source:
     git_rev: master
     git_url: https://github.com/h5py/h5py.git
 
+build:
+    number: 1
+
 requirements:
   build:
     - python


### PR DESCRIPTION
Due to hdf5 library issues h5py should be built on our reference machines.