### PR TITLE
Fix epics-base build on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,6 @@
+init:
+  - git config --global core.autocrlf false
+
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 init:
-  - git config --global core.autocrlf false
+  - git config --global core.autocrlf true
 
 environment:
   global:
@@ -24,10 +24,6 @@ install:
   - conda update -q --all
   - conda config --add channels defaults
   - conda install conda-build numpy anaconda-client
-  # replace patch with m2-patch
-  # https://github.com/conda/conda-build/issues/2307
-  - conda remove patch
-  - conda install m2-patch
   # build
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing brotli"
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing bottle"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,10 @@ install:
   - conda update -q --all
   - conda config --add channels defaults
   - conda install conda-build numpy anaconda-client
+  # replace patch with m2-patch
+  # https://github.com/conda/conda-build/issues/2307
+  - conda remove patch
+  - conda install m2-patch
   # build
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing brotli"
   - "%CMD_IN_ENV% conda build -c %CONDA_CHANNEL% --skip-existing bottle"

--- a/epics-base/meta.yaml
+++ b/epics-base/meta.yaml
@@ -18,6 +18,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
     - m2w64-make [win]
     - perl [win]
     - patch [win]

--- a/epics-base/pre-build.py
+++ b/epics-base/pre-build.py
@@ -9,7 +9,7 @@ EPICS_INSTALL_PATH = os.path.join(PREFIX, 'epics')
 EPICS_BIN_PATH = os.path.join(EPICS_INSTALL_PATH, 'bin', EPICS_HOST_ARCH)
 
 # set INSTALLATION_LOCATION in CONFIG_SITE
-open('configure/CONFIG_SITE', 'ab').write('\nINSTALL_LOCATION = $(TOP)/%s\n' % os.path.relpath(EPICS_INSTALL_PATH, os.path.curdir).replace('\\', '/'))
+open('configure/CONFIG_SITE', 'ab').write(('\nINSTALL_LOCATION = $(TOP)/%s\n' % os.path.relpath(EPICS_INSTALL_PATH, os.path.curdir).replace('\\', '/')).encode('utf8'))
 
 # create an epics-base.pth file so that epics bin dir is added to the PATH
 if not os.path.exists(SP_DIR):


### PR DESCRIPTION
Three issues are fixed:
- pre-build.py is made python 3 compatible
- let git checkout code with CRLF line ending to satisfy patch program
- avoid conda-build warning by declaring cxx dependency.